### PR TITLE
feat: support liveness and readiness healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,56 @@ For deployments that use a `rollingUpdate` for rollouts, a `rollingUpdate` may b
 dokku scheduler-kubernetes:rolling-update APP
 ```
 
+Health checks for the app may be configured in `app.json`, based on [Kubernetes
+liveness and readiness
+probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/).
+All Kubernetes options that can occur within a [Probe
+object](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#probe-v1-core)
+are supported, though syntax is JSON rather than YAML. The variable `$APP` may
+be used to represent the app name.
+
+If a process type is not configured for a given probe type (liveness or
+readiness), any probe of the same type for the `"*"` default process type is
+used instead.
+
+<details><summary>Here (click the triangle to expand) is an example JSON for
+Kubernetes health checks.</summary><p>
+
+```json
+{
+	"healthchecks": {
+		"web": {
+			"readiness": {
+				"httpGet": {
+					"path": "/{{ $APP }}/readiness_check",
+					"port": 5000
+				},
+				"initialDelaySeconds": 5,
+				"periodSeconds": 5
+			}
+		},
+		"*": {
+			"liveness": {
+				"exec": {
+					"command": ["/bin/pidof", "/start"]
+				},
+				"initialDelaySeconds": 5,
+				"periodSeconds": 5
+			},
+			"readiness": {
+				"httpGet": {
+					"path": "web processes override this.",
+					"port": 5000
+				},
+				"initialDelaySeconds": 5,
+				"periodSeconds": 5
+			}
+		}
+	}
+}
+```
+</p></details>
+
 ## Notes
 
 - Dockerfile deploys are not currently supported.

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -75,6 +75,35 @@ fn-set-resource-constraints() {
   fi
 }
 
+fn-set-healthchecks() {
+  declare APP="$1" PROC_TYPE="$2" DEPLOYMENT_FILE="$3"
+  local TMP_DIR=$(mktemp -d "/tmp/${FUNCNAME[0]}.XXXX")
+  local APP_JSON_TMPL="$TMP_DIR/app.json.sigil"
+  local APP_JSON_FILE="$TMP_DIR/app.json"
+  local PROBE_FILE="$TMP_DIR/probe.json"
+  local DEPLOYMENT_TMP_FILE="$TMP_DIR/deployment.json"
+  trap 'rm -rf "$TMP_DIR" > /dev/null' RETURN INT TERM EXIT
+
+  copy_from_image "$IMAGE" "app.json" "$APP_JSON_TMPL" 2>/dev/null || true
+
+  if [[ ! -f "$APP_JSON_TMPL" ]]; then
+    return 0
+  fi
+
+  # We use sigil templating to allow the health check configurations to refer
+  # to the app name with the variable $APP.
+  SIGIL_PARAMS=(APP="$APP")
+  sigil -f "$APP_JSON_TMPL" "${SIGIL_PARAMS[@]}" | cat -s >$APP_JSON_FILE
+
+  for PROBE_TYPE in liveness readiness; do
+    if     jq -e -M ".healthchecks.\"$PROC_TYPE\".\"$PROBE_TYPE\"" <"$APP_JSON_FILE" >"$PROBE_FILE" \
+       ||  jq -e -M ".healthchecks.\"*\".\"$PROBE_TYPE\"" <"$APP_JSON_FILE" >"$PROBE_FILE"; then
+      jq -M --argjson data "$(cat "$PROBE_FILE")" ".spec.template.spec.containers[0].${PROBE_TYPE}Probe += \$data" <"$DEPLOYMENT_FILE" >"$DEPLOYMENT_TMP_FILE"
+      mv "$DEPLOYMENT_TMP_FILE" "$DEPLOYMENT_FILE"
+    fi
+  done
+}
+
 scheduler-kubernetes-scheduler-deploy() {
   declare desc="deploys an image tag for a given application"
   declare trigger="scheduler-kubernetes scheduler-deploy"
@@ -124,6 +153,7 @@ scheduler-kubernetes-scheduler-deploy() {
     fn-set-ports "$APP" "$TMP_FILE"
     fn-set-resource-constraints "$APP" "$PROC_TYPE" "$TMP_FILE"
     fn-set-image-pull-secrets "$IMAGE_PULL_SECRETS" "$TMP_FILE"
+    fn-set-healthchecks "$APP" "$PROC_TYPE" "$TMP_FILE"
 
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" apply -f "$TMP_FILE" | sed "s/^/       /"
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubedog" "${KUBE_ARGS[@]}" --timeout=600 rollout track deployment "${APP}-${PROC_TYPE}"


### PR DESCRIPTION
Tested successfully with an `app.json` matching the expected format. Double plus testing: I initially made the mistake of specifying the port as 80 in the JSON when I meant 5000, and I saw error messages during the deploy about the app being unhealthy because the readiness probe got a connection refused. :) It deploys successfully after fixing that, and the probes show up in Kubernetes.

One detail of how I resolved an ambiguity in our spec: With this implementation, the liveness and readiness probes fall back separately to `"*"` if that particular probe type is not specified for for the particular process type. In other words, if `"*"` gives a default for both liveness and readiness probes, overriding one of those probes for a specific process type will not remove the other probe. This seems better to me than the alternative, with a further enhancement possible to allow specifying `null` or `[]` or some other empty-sh concept to explicitly remove a default probe for a process type.

CC @plotly/devops.