### PR TITLE
Post-deploy hook to create fake app containerfile

### DIFF
--- a/post-deploy-fake-containerfile
+++ b/post-deploy-fake-containerfile
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Creates fake containerfile so ps:rebuild check for deployed app succeeds
+# Hacky -- consider replacing with check for valid git repo
+
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+source "$PLUGIN_AVAILABLE_PATH/scheduler-kubernetes/internal-functions"
+
+scheduler-kubernetes-post-deploy() {
+  declare desc="Creates fake containerfile to work around bug in ps:rebuild"
+  declare trigger="scheduler-kubernetes-post-deploy"
+  declare DOKKU_SCHEDULER="$1" APP="$2"
+
+  if [[ "$DOKKU_SCHEDULER" != "kubernetes" ]]; then
+    return
+  fi
+
+touch "$DOKKU_ROOT/$APP/CONTAINER.fakefile"
+}
+
+scheduler-kubernetes-post-deploy "$@"


### PR DESCRIPTION
Hacky work-around to help https://github.com/plotly/streambed/issues/13080 work by creating a fake `CONTAINER.*.*` file for apps deployed on a high-availability cluster so that the `is_deployed` check in `ps:rebuildall` works.