### PR TITLE
Set the imagePullPolicy to Always to not use cached images

### DIFF
--- a/templates/deployment.json.sigil
+++ b/templates/deployment.json.sigil
@@ -38,6 +38,7 @@
             ],
             "env": [],
             "image": "{{ $.IMAGE }}",
+            "imagePullPolicy": "Always",
             "name": "{{ $.APP }}-{{ $.PROCESS_TYPE }}",
             "ports": [
               {


### PR DESCRIPTION
This PR adds the `imagePullPolicy` property and sets it to `Always` in order to force Kubernetes to not use any cached images.