### PR TITLE
Update to kubedog 0.3.4 to support k8s >= 1.16

### DIFF
--- a/install
+++ b/install
@@ -23,7 +23,7 @@ scheduler-kubernetes-install() {
   fi
 
   local KUBEDOG_VENDOR_URL="${KUBEDOG_VENDOR_URL:-"https://dl.bintray.com"}"
-  local KUBEDOG_VERSION="${KUBEDOG_VERSION:-v0.2.0}"
+  local KUBEDOG_VERSION="${KUBEDOG_VERSION:-v0.3.4}"
   if [[ ! -f "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubedog-${KUBEDOG_VERSION}" ]]; then
     dokku_log_info1_quiet "Installing kubedog@${KUBEDOG_VERSION}"
     curl -sL "${KUBEDOG_VENDOR_URL}/flant/kubedog/${KUBEDOG_VERSION}/kubedog-linux-amd64-${KUBEDOG_VERSION}" -o "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubedog-${KUBEDOG_VERSION}"


### PR DESCRIPTION
kubedog versions prior to 0.3.4 use "beta" API versions that were deprecated in Kubernetes 1.9 and removed in 1.16.

* [x] Tested with Kubernetes 1.16
* [x] Tested with older Kubernetes

@josegonzalez FYI