### PR TITLE
Arbitrary services

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Set the scheduler to `kubernetes`. This can be done per-app or globally:
 dokku config:set --global DOKKU_SCHEDULER=kubernetes
 
 # per-app
-dokku config:set APP DOKKU_SCHEDULER=kubernetes
+dokku config:set $APP DOKKU_SCHEDULER=kubernetes
 ```
 
 You also need to ensure your kubectl has the correct context specified:
@@ -78,7 +78,7 @@ kubectl config use-context YOUR_NAME
 And configure your registry:
 
 ```shell
-dokku registry:set APP server gcr.io/dokku/
+dokku registry:set $APP server gcr.io/dokku/
 ```
 
 Assuming your Dokku installation can push to the registry and your kubeconfig is valid, Dokku will deploy the app against the cluster.
@@ -86,13 +86,13 @@ Assuming your Dokku installation can push to the registry and your kubeconfig is
 The namespace in use for a particular app can be customized using the `:set` command. This will apply to all future invocations of the plugin, and will not modify any existing resources. If unspecified, the namespace in use is the cluster default namespace. The `scheduler-kubernetes` will create the namespace via a `kubectl apply`.
 
 ```shell
-dokku scheduler-kubernetes:set APP namespace test
+dokku scheduler-kubernetes:set $APP namespace test
 ```
 
 If deploying from a private docker registry and the cluster needs does not have open access to the registry, an `imagePullSecrets` value can be specified. This will be injected into the kubernetes deployment spec at deploy time.
 
 ```shell
-dokku scheduler-kubernetes:set APP imagePullSecrets registry-credential
+dokku scheduler-kubernetes:set $APP imagePullSecrets registry-credential
 ```
 
 > See [this doc](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more details on creating an `imagePullSecrets` secret file.
@@ -108,7 +108,7 @@ dokku scheduler-kubernetes:set APP imagePullSecrets registry-credential
 A Kubernetes service object is created for each `web` process. Additionally, if the app has it's `proxy-type` set to `nginx-ingress`, then we will also create or update a Kubernetes ingress object within the namespace configured for the app. This can be set as follows:
 
 ```shell
-dokku config:set APP DOKKU_APP_PROXY_TYPE=nginx-ingress
+dokku config:set $APP DOKKU_APP_PROXY_TYPE=nginx-ingress
 ```
 
 The ingress object has the following properties:
@@ -133,7 +133,7 @@ To modify the manifest before it gets applied to the cluster, use the `pre-kuber
 
 At this time, the `scheduler-kubernetes` does not have support for custom SSL certificates. However, domains associated with an app can have a Letsencrypt SSL certificate provisioned automatically via the [CertManager](https://github.com/jetstack/cert-manager) Kubernetes add-on.
 
-To start using the CertManager, we'll first need to set the issuer email
+To start using the CertManager, we will first need to set the issuer email
 
 ```shell
 dokku config:set --global CERT_MANAGER_EMAIL=your@email.tld
@@ -142,7 +142,7 @@ dokku config:set --global CERT_MANAGER_EMAIL=your@email.tld
 Next, any apps that will require cert-manager integration will need to have that enabled:
 
 ```shell
-dokku scheduler-kubernetes:set APP cert-manager-enabled true
+dokku scheduler-kubernetes:set $APP cert-manager-enabled true
 ```
 
 On the next deploy or domain name change, the CertManager entry will be automatically updated to fetch an SSL certificate for all domains associated with all applications on the same ingress object.
@@ -152,10 +152,10 @@ On the next deploy or domain name change, the CertManager entry will be automati
 A PodDisruptionBudget object can be created, and will apply to all process types in an app. To configure this, the `pod-max-unavailable` and `pod-min-available` properties can be set:
 
 ```shell
-dokku scheduler-kubernetes:set APP pod-min-available 1
+dokku scheduler-kubernetes:set $APP pod-min-available 1
 
 # available in kubernetes 1.7+
-dokku scheduler-kubernetes:set APP pod-max-unavailable 1
+dokku scheduler-kubernetes:set $APP pod-max-unavailable 1
 ```
 
 Pod Disruption Budgets will be updated on next deploy.
@@ -170,10 +170,10 @@ At a minimum, both a min/max number of replicas must be set.
 
 ```shell
 # set the min number of replicas
-dokku scheduler-kubernetes:autoscale-set APP PROC_TYPE min-replicas 1
+dokku scheduler-kubernetes:autoscale-set $APP PROC_TYPE min-replicas 1
 
 # set the max number of replicas
-dokku scheduler-kubernetes:autoscale-set APP PROC_TYPE max-replicas 10
+dokku scheduler-kubernetes:autoscale-set $APP PROC_TYPE max-replicas 10
 ```
 
 You also need to add autoscaling rules. These can be managed via the `:autoscale-rule-add` command. Adding a rule for a target-name/metric-type combination that already exists will override any existing rules.
@@ -209,29 +209,29 @@ Rules can be added for the following metric types:
 
 ```shell
 # set the cpu average utilization target
-dokku scheduler-kubernetes:autoscale-rule-add APP PROC_TYPE resource:cpu:Utilization:50
+dokku scheduler-kubernetes:autoscale-rule-add $APP PROC_TYPE resource:cpu:Utilization:50
 ```
 
 Rules can be listed via the `autoscale-rule-list` command:
 
 ```shell
-dokku scheduler-kubernetes:autoscale-rule-list APP PROC_TYPE
+dokku scheduler-kubernetes:autoscale-rule-list $APP PROC_TYPE
 ```
 
 Rules can be removed via the `:autoscale-rule-remove` command. This command takes the same arguments as the `autoscale-rule-add` command, though the value is optional. If a rule matching the specified arguments does not exist, the command will still return 0.
 
 ```shell
 # remove the cpu rule
-dokku scheduler-kubernetes:autoscale-rule-remove APP PROC_TYPE resource:cpu:Utilization:50
+dokku scheduler-kubernetes:autoscale-rule-remove $APP PROC_TYPE resource:cpu:Utilization:50
 
 # remove the cpu rule by prefix
-dokku scheduler-kubernetes:autoscale-rule-remove APP PROC_TYPE resource:cpu:Utilization
+dokku scheduler-kubernetes:autoscale-rule-remove $APP PROC_TYPE resource:cpu:Utilization
 ```
 
 Autoscaling rules are applied automatically during the next deploy, though may be immediately applied through the `:autoscale-rule-apply` command:
 
 ```shell
-dokku scheduler-kubernetes:autoscale-rule-apply APP PROC_TYPE
+dokku scheduler-kubernetes:autoscale-rule-apply $APP PROC_TYPE
 ```
 
 ### Kubernetes Manifests
@@ -242,7 +242,7 @@ The kubernetes manifest for a deployment or service can be displayed using the `
 
 ```shell
 # show the deployment manifest for the `web` process type
-dokku scheduler-kubernetes:show-manifest APP PROC_TYPE MANIFEST_TYPE
+dokku scheduler-kubernetes:show-manifest $APP PROC_TYPE MANIFEST_TYPE
 ```
 
 This command can be used like so:
@@ -271,7 +271,7 @@ These can be managed by the `:deployment-annotations-set` command.
 
 ```shell
 # command structure
-dokku scheduler-kubernetes:deployment-annotations-set APP name value
+dokku scheduler-kubernetes:deployment-annotations-set $APP name value
 
 # set example
 dokku scheduler-kubernetes:deployment-annotations-set node-js-sample pod.kubernetes.io/lifetime 86400s
@@ -288,7 +288,7 @@ These can be managed by the `:pod-annotations-set` command.
 
 ```shell
 # command structure
-dokku scheduler-kubernetes:pod-annotations-set APP name value
+dokku scheduler-kubernetes:pod-annotations-set $APP name value
 
 # set example
 dokku scheduler-kubernetes:pod-annotations-set node-js-sample pod.kubernetes.io/lifetime 86400s
@@ -305,7 +305,7 @@ These can be managed by the `:service-annotations-set` command.
 
 ```shell
 # command structure
-dokku scheduler-kubernetes:service-annotations-set APP name value
+dokku scheduler-kubernetes:service-annotations-set $APP name value
 
 # set example
 dokku scheduler-kubernetes:service-annotations-set node-js-sample pod.kubernetes.io/lifetime 86400s
@@ -321,7 +321,7 @@ Currently, they are applied to the `web` process, which is the only process for 
 For deployments that use a `rollingUpdate` for rollouts, a `rollingUpdate` may be triggered at a later date via the `:rolling-update` command.
 
 ```shell
-dokku scheduler-kubernetes:rolling-update APP
+dokku scheduler-kubernetes:rolling-update $APP
 ```
 
 ### Health Checks

--- a/internal-functions
+++ b/internal-functions
@@ -81,6 +81,7 @@ cmd-scheduler-kubernetes-report-single() {
     "--scheduler-kubernetes-namespace: $(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
     "--scheduler-kubernetes-pod-max-unavailable: $(fn-plugin-property-get "scheduler-kubernetes" "$APP" "pod-max-unavailable" "")"
     "--scheduler-kubernetes-pod-min-available: $(fn-plugin-property-get "scheduler-kubernetes" "$APP" "pod-min-available" "")"
+    "--scheduler-kubernetes-service-process-types: $(fn-plugin-property-get "scheduler-kubernetes" "$APP" "service-process-types" "")"
   )
 
   if [[ -z "$INFO_FLAG" ]]; then

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -38,7 +38,7 @@ scheduler-kubernetes-scheduler-deploy() {
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
   fi
 
-  IMAGE_PULL_SECRETS="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "imagePullSecrets" "")"
+  local IMAGE_PULL_SECRETS="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "imagePullSecrets" "")"
 
   local SERVICE_PROCESS_TYPES=$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "service-process-types" "")
   local VALID_SERVICE_TYPES

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -65,7 +65,8 @@ scheduler-kubernetes-scheduler-deploy() {
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" apply -f "$TMP_FILE" | sed "s/^/       /"
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubedog" "${KUBE_ARGS[@]}" --timeout=600 rollout track deployment "${APP}-${PROC_TYPE}"
 
-    if [[ "$PROC_TYPE" == "web" ]]; then
+    local VALID_SERVICE_TYPES=("web")
+    if fn-in-array "$PROC_TYPE" "${VALID_SERVICE_TYPES[@]}"; then
       sigil -f "$SERVICE_TEMPLATE" "${SIGIL_PARAMS[@]}" | cat -s >$TMP_FILE
       fn-set-service-annotations "$APP" "$TMP_FILE"
       plugn trigger pre-deploy-kubernetes-apply "$APP" "$PROC_TYPE" "$TMP_FILE" service

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -40,6 +40,13 @@ scheduler-kubernetes-scheduler-deploy() {
 
   IMAGE_PULL_SECRETS="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "imagePullSecrets" "")"
 
+  local SERVICE_PROCESS_TYPES=$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "service-process-types" "")
+  local VALID_SERVICE_TYPES
+  if [[ -n "$SERVICE_PROCESS_TYPES" ]]; then
+    IFS=',' read -ra VALID_SERVICE_TYPES <<<"$SERVICE_PROCESS_TYPES"
+  fi
+  VALID_SERVICE_TYPES+=("web")
+
   while read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^#.* ]] && continue
     line="$(strip_inline_comments "$line")"
@@ -65,7 +72,6 @@ scheduler-kubernetes-scheduler-deploy() {
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" apply -f "$TMP_FILE" | sed "s/^/       /"
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubedog" "${KUBE_ARGS[@]}" --timeout=600 rollout track deployment "${APP}-${PROC_TYPE}"
 
-    local VALID_SERVICE_TYPES=("web")
     if fn-in-array "$PROC_TYPE" "${VALID_SERVICE_TYPES[@]}"; then
       sigil -f "$SERVICE_TEMPLATE" "${SIGIL_PARAMS[@]}" | cat -s >$TMP_FILE
       fn-set-service-annotations "$APP" "$TMP_FILE"

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -70,7 +70,6 @@ scheduler-kubernetes-scheduler-deploy() {
       fn-set-service-annotations "$APP" "$TMP_FILE"
       plugn trigger pre-deploy-kubernetes-apply "$APP" "$PROC_TYPE" "$TMP_FILE" service
       "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" apply -f "$TMP_FILE" | sed "s/^/       /"
-      # "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubedog" "${KUBE_ARGS[@]}" --timeout=600 rollout track service "${APP}-${PROC_TYPE}"
     fi
 
     plugn trigger post-deploy-kubernetes-apply "$APP" "$PROC_TYPE" "$TMP_FILE" deployment

--- a/subcommands/set
+++ b/subcommands/set
@@ -9,13 +9,13 @@ cmd-scheduler-kubernetes-set() {
   declare cmd="scheduler-kubernetes:set" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("cert-manager-enabled" "imagePullSecrets" "ingress-enabled" "namespace" "pod-max-unavailable" "pod-min-available")
+  local VALID_KEYS=("cert-manager-enabled" "imagePullSecrets" "ingress-enabled" "namespace" "pod-max-unavailable" "pod-min-available" "service-process-types")
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   verify_app_name "$APP"
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: cert-manager-enabled, imagePullSecrets, ingress-enabled, namespace, pod-max-unavailable, pod-min-available"
+    dokku_log_fail "Invalid key specified, valid keys include: cert-manager-enabled, imagePullSecrets, ingress-enabled, namespace, pod-max-unavailable, pod-min-available, service-process-types"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/subcommands/show-manifest
+++ b/subcommands/show-manifest
@@ -27,6 +27,7 @@ cmd-scheduler-kubernetes-show-manifest() {
   local IMAGE_TAG="$(get_running_image_tag "$APP")"
   local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
 
+  local IMAGE_PULL_SECRETS="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "imagePullSecrets" "")"
   local SERVICE_PROCESS_TYPES=$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "service-process-types" "")
   local VALID_SERVICE_TYPES
   if [[ -n "$SERVICE_PROCESS_TYPES" ]]; then

--- a/subcommands/show-manifest
+++ b/subcommands/show-manifest
@@ -27,6 +27,13 @@ cmd-scheduler-kubernetes-show-manifest() {
   local IMAGE_TAG="$(get_running_image_tag "$APP")"
   local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
 
+  local SERVICE_PROCESS_TYPES=$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "service-process-types" "")
+  local VALID_SERVICE_TYPES
+  if [[ -n "$SERVICE_PROCESS_TYPES" ]]; then
+    IFS=',' read -ra VALID_SERVICE_TYPES <<<"$SERVICE_PROCESS_TYPES"
+  fi
+  VALID_SERVICE_TYPES+=("web")
+
   while read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^#.* ]] && continue
     line="$(strip_inline_comments "$line")"
@@ -56,7 +63,7 @@ cmd-scheduler-kubernetes-show-manifest() {
       return
     fi
 
-    if [[ "$PROC_TYPE" == "web" ]]; then
+    if fn-in-array "$PROC_TYPE" "${VALID_SERVICE_TYPES[@]}"; then
       sigil -f "$SERVICE_TEMPLATE" "${SIGIL_PARAMS[@]}" | cat -s >$TMP_FILE
       fn-set-service-annotations "$APP" "$TMP_FILE"
       plugn trigger pre-deploy-kubernetes-apply "$APP" "$PROC_TYPE" "$TMP_FILE" service


### PR DESCRIPTION
This PR allows whitelisting arbitrary process types for Kubernetes services. These services won't create any ingress object - domains are only attached to the web process, as per general Heroku/PaaS standards - but otherwise make services routeable.

Note that the same limitations around ports still apply, so applications should either listen on port 5000 or respect the PORT environment variable (which inevitably sets 5000 as the port).