### PR TITLE
fix: do not run post-extract hook when the scheduler is not kubernetes

### DIFF
--- a/post-extract
+++ b/post-extract
@@ -8,6 +8,11 @@ scheduler-kubernetes-post-extract() {
   declare trigger="scheduler-kubernetes-post-extract"
   declare APP="$1" TMP_WORK_DIR="$2" REV="$3"
 
+  local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
+  if [[ "$DOKKU_SCHEDULER" != "kubernetes" ]]; then
+    return
+  fi
+
   pushd "$TMP_WORK_DIR" >/dev/null
   for process_type in $(procfile-util list); do
     if echo "$process_type" | grep -vqE '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'; then


### PR DESCRIPTION
This allows underscores to be used for process type names.