### PR TITLE
Force apps missing namespaces to use the default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ dokku registry:set $APP server gcr.io/dokku/
 
 Assuming your Dokku installation can push to the registry and your kubeconfig is valid, Dokku will deploy the app against the cluster.
 
-The namespace in use for a particular app can be customized using the `:set` command. This will apply to all future invocations of the plugin, and will not modify any existing resources. If unspecified, the namespace in use is the cluster default namespace. The `scheduler-kubernetes` will create the namespace via a `kubectl apply`.
+The namespace in use for a particular app can be customized using the `:set` command. This will apply to all future invocations of the plugin, and will not modify any existing resources. If unspecified, the namespace in use is the cluster "default" namespace. The `scheduler-kubernetes` will create the namespace via a `kubectl apply`.
 
 ```shell
 dokku scheduler-kubernetes:set $APP namespace test

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ dokku registry:set $APP server gcr.io/dokku/
 
 Assuming your Dokku installation can push to the registry and your kubeconfig is valid, Dokku will deploy the app against the cluster.
 
-The namespace in use for a particular app can be customized using the `:set` command. This will apply to all future invocations of the plugin, and will not modify any existing resources. If unspecified, the namespace in use is the cluster "default" namespace. The `scheduler-kubernetes` will create the namespace via a `kubectl apply`.
+The namespace in use for a particular app can be customized using the `:set` command. This will apply to all future invocations of the plugin, and will not modify any existing resources. If unspecified, the namespace in use is the cluster `default` namespace. The `scheduler-kubernetes` will create the namespace via a `kubectl apply`.
 
 ```shell
 dokku scheduler-kubernetes:set $APP namespace test

--- a/internal-functions
+++ b/internal-functions
@@ -28,13 +28,9 @@ cmd-scheduler-kubernetes-rolling-update() {
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   dokku_log_info1 "Triggering rolling-update for $APP"
   while read -r line || [[ -n "$line" ]]; do
@@ -200,13 +196,9 @@ fn-scheduler-kubernetes-autoscale-apply() {
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   RULES="$(fn-plugin-property-list-get "scheduler-kubernetes" "$APP" "autoscale.$PROC_TYPE")"
   if [[ -z "$RULES" ]]; then
@@ -344,7 +336,7 @@ fn-scheduler-kubernetes-ingress-build-config() {
   fi
 
   local HAS_RULE=false
-  local APP_NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
+  local APP_NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
   local INGRESS_TEMPLATE="$PLUGIN_AVAILABLE_PATH/scheduler-kubernetes/templates/ingress.json.sigil"
 
   local SIGIL_PARAMS=()
@@ -353,7 +345,7 @@ fn-scheduler-kubernetes-ingress-build-config() {
   for app in $(dokku_apps); do
     local DOKKU_SCALE_FILE="$DOKKU_ROOT/$app/DOKKU_SCALE"
     local DOKKU_VHOST_FILE="$DOKKU_ROOT/$app/VHOST"
-    local namespace="$(fn-plugin-property-get "scheduler-kubernetes" "$app" "namespace" "")"
+    local namespace="$(fn-plugin-property-get "scheduler-kubernetes" "$app" "namespace" "default")"
     local cert_manager_enabled="$(fn-plugin-property-get "scheduler-kubernetes" "$app" "cert-manager-enabled" "")"
 
     if [[ "$APP_NAMESPACE" != "$namespace" ]]; then
@@ -398,12 +390,8 @@ fn-scheduler-kubernetes-ingress-build-config() {
   fi
 
   local KUBE_ARGS=()
-  if [[ -n "$APP_NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$APP_NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$APP_NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  KUBE_ARGS+=("--namespace=$APP_NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$APP_NAMESPACE" >/dev/null
 
   local SCHEME=http
   if [[ -n "$CERT_MANAGER_EMAIL" ]] && [[ -n "$CERT_MANAGER_DOMAINS" ]]; then
@@ -424,6 +412,9 @@ fn-scheduler-kubernetes-ingress-build-config() {
 
 fn-scheduler-kubernetes-ensure-namespace() {
   declare NAMESPACE="$1"
+  if [[  "$NAMESPACE" = "default" ]]; then
+    return
+  fi
   local NAMESPACE_TEMPLATE="$PLUGIN_AVAILABLE_PATH/scheduler-kubernetes/templates/namespace.json.sigil"
   local TMP_FILE=$(mktemp "/tmp/${FUNCNAME[0]}.XXXX")
   trap 'rm -rf "$TMP_FILE" > /dev/null' RETURN INT TERM EXIT
@@ -551,13 +542,9 @@ fn-set-pod-disruption-constraints() {
 
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   local SIGIL_PARAMS=(APP="$APP")
   sigil -f "$DEPLOYMENT_TEMPLATE" "${SIGIL_PARAMS[@]}" | cat -s >$POD_TMP_FILE

--- a/internal-functions
+++ b/internal-functions
@@ -32,6 +32,8 @@ cmd-scheduler-kubernetes-rolling-update() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   dokku_log_info1 "Triggering rolling-update for $APP"
@@ -202,6 +204,8 @@ fn-scheduler-kubernetes-autoscale-apply() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   RULES="$(fn-plugin-property-list-get "scheduler-kubernetes" "$APP" "autoscale.$PROC_TYPE")"
@@ -397,6 +401,8 @@ fn-scheduler-kubernetes-ingress-build-config() {
   if [[ -n "$APP_NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$APP_NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$APP_NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   local SCHEME=http
@@ -549,6 +555,8 @@ fn-set-pod-disruption-constraints() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   local SIGIL_PARAMS=(APP="$APP")

--- a/scheduler-app-status
+++ b/scheduler-app-status
@@ -21,6 +21,8 @@ scheduler-app-status() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   local PROCS=0 RUNNING=""

--- a/scheduler-app-status
+++ b/scheduler-app-status
@@ -17,13 +17,9 @@ scheduler-app-status() {
 
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   local PROCS=0 RUNNING=""
   KUBE_OUTPUT="$("${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" get pods --selector app="$APP" -o custom-columns="STATUS:.status.conditions[?(@.type=='Ready')].status" --no-headers 2>/dev/null || true)"

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -32,13 +32,9 @@ scheduler-kubernetes-scheduler-deploy() {
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   local IMAGE_PULL_SECRETS="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "imagePullSecrets" "")"
 

--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -36,6 +36,8 @@ scheduler-kubernetes-scheduler-deploy() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   local IMAGE_PULL_SECRETS="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "imagePullSecrets" "")"

--- a/scheduler-is-deployed
+++ b/scheduler-is-deployed
@@ -19,12 +19,9 @@ scheduler-kubernetes-scheduler-is-deployed() {
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
   NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   KUBE_OUTPUT="$("${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" get pods --selector app="$APP" -o name 2>/dev/null || true)"
   if [[ -n "$KUBE_OUTPUT" ]]; then

--- a/scheduler-is-deployed
+++ b/scheduler-is-deployed
@@ -22,6 +22,8 @@ scheduler-kubernetes-scheduler-is-deployed() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   KUBE_OUTPUT="$("${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" get pods --selector app="$APP" -o name 2>/dev/null || true)"

--- a/scheduler-logs
+++ b/scheduler-logs
@@ -27,6 +27,8 @@ scheduler-kubernetes-scheduler-logs() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   local LOGS_ARGS="--tail $NUM"

--- a/scheduler-logs
+++ b/scheduler-logs
@@ -23,13 +23,9 @@ scheduler-kubernetes-scheduler-logs() {
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   local LOGS_ARGS="--tail $NUM"
   [[ "$TAIL" == "true" ]] && LOGS_ARG+=" --follow "

--- a/scheduler-post-delete
+++ b/scheduler-post-delete
@@ -18,13 +18,9 @@ scheduler-kubernetes-scheduler-post-delete() {
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" delete deployments,hpa,pdb,pods,services -l app="$APP"
 }

--- a/scheduler-post-delete
+++ b/scheduler-post-delete
@@ -22,6 +22,8 @@ scheduler-kubernetes-scheduler-post-delete() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" delete deployments,hpa,pdb,pods,services -l app="$APP"

--- a/scheduler-stop
+++ b/scheduler-stop
@@ -23,13 +23,9 @@ scheduler-kubernetes-scheduler-stop() {
   export KUBECONFIG="${DOKKU_ROOT}/.kube/config"
   export KUBEDOG_KUBE_CONFIG="${DOKKU_ROOT}/.kube/config"
   KUBE_ARGS=()
-  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "")"
-  if [[ -n "$NAMESPACE" ]]; then
-    KUBE_ARGS+=("--namespace=$NAMESPACE")
-    fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
-  else
-    KUBE_ARGS+=("--namespace=default")
-  fi
+  NAMESPACE="$(fn-plugin-property-get "scheduler-kubernetes" "$APP" "namespace" "default")"
+  KUBE_ARGS+=("--namespace=$NAMESPACE")
+  fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
 
   while read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^#.* ]] && continue

--- a/scheduler-stop
+++ b/scheduler-stop
@@ -27,6 +27,8 @@ scheduler-kubernetes-scheduler-stop() {
   if [[ -n "$NAMESPACE" ]]; then
     KUBE_ARGS+=("--namespace=$NAMESPACE")
     fn-scheduler-kubernetes-ensure-namespace "$NAMESPACE" >/dev/null
+  else
+    KUBE_ARGS+=("--namespace=default")
   fi
 
   while read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
When a namesapce is defined by using `dokku scheduler-kubernetes:set $APP namespace test`, subsequent request via kubectl calls will use this set namespace for app like `kubectl --namespace=test apply -f ...`
However, when a namespace is not defined for an app subsequent kubectl calls will use  for example `kubectl apply -f ...` without specifying a namespace.
The assumption here is that  kubectl will use the `default` namespace, however if one has changed context  via `kubectl config set-context --current --namespace=pxc`, all such kubectl calls missing the --namespace flag will use the pxc namespace instead of default.
The purpose of this PR is to force all such kubectl calls for apps without a namespace defined to use the `default` namespace by default