### PR TITLE
Procfile command isn't necessary here

### DIFF
--- a/scheduler-deploy
+++ b/scheduler-deploy
@@ -70,8 +70,9 @@ scheduler-kubernetes-scheduler-deploy() {
     fn-set-deployment-annotations "$APP" "$TMP_FILE"
     fn-set-pod-annotations "$APP" "$TMP_FILE"
     fn-set-mount "$APP" "$TMP_FILE"
-    fn-set-command-and-args "$APP" "$PROC_TYPE" "$IMAGE_SOURCE_TYPE" "$TMP_FILE"
-
+    if [[ "$IMAGE_SOURCE_TYPE" != "pack" ]]; then
+      fn-set-command-and-args "$APP" "$PROC_TYPE" "$IMAGE_SOURCE_TYPE" "$TMP_FILE"
+    fi
     plugn trigger pre-deploy-kubernetes-apply "$APP" "$PROC_TYPE" "$TMP_FILE" deployment
 
     "${DOKKU_LIB_ROOT}/data/scheduler-kubernetes/kubectl" "${KUBE_ARGS[@]}" apply -f "$TMP_FILE" | sed "s/^/       /"

--- a/subcommands/show-manifest
+++ b/subcommands/show-manifest
@@ -60,7 +60,9 @@ cmd-scheduler-kubernetes-show-manifest() {
     fn-set-deployment-annotations "$APP" "$TMP_FILE"
     fn-set-pod-annotations "$APP" "$TMP_FILE"
     fn-set-mount "$APP" "$TMP_FILE"
-    fn-set-command-and-args "$APP" "$PROC_TYPE" "$IMAGE_SOURCE_TYPE" "$TMP_FILE"
+    if [[ "$IMAGE_SOURCE_TYPE" != "pack" ]]; then
+      fn-set-command-and-args "$APP" "$PROC_TYPE" "$IMAGE_SOURCE_TYPE" "$TMP_FILE"
+    fi
 
     plugn trigger pre-deploy-kubernetes-apply "$APP" "$PROC_TYPE" "$TMP_FILE" deployment
     if [[ "$MANIFEST_TYPE" == "deployment" ]]; then


### PR DESCRIPTION
Hi @josegonzalez, I know this plugin isn't actively developed (as there is a K3s plugin in place, but we aren't yet ready to switch to k3s as k3s still lacks PVC support), but I would still like to merge this change. 
I have found that for `pack`- based images, this scheduler still wants to use the Procfile-based command, and if the command isn't there, it simply fails. 
This small change resolves this issue. 